### PR TITLE
Make the progress animation smoother

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -21,8 +21,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		var stylesIterator = styles.makeIterator()
 		_ = stylesIterator.next()
 
-		Timer.scheduledTimer(withTimeInterval: 0.02, repeats: true) { _ in
-			DockProgress.progress += 0.01
+		Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
+			DockProgress.progress += 0.05
 
 			if DockProgress.progress > 1 {
 				if let style = stylesIterator.next() {


### PR DESCRIPTION
Fixes #1 

When you change the progress variable it schedules evenly spaces calls to change the animatedProgress variable. The animatedProgress variable then changes the previous progress and calls updateDockIcon()

public variables:
stepDuration - Default Value: 0.05 (5ms) - How long to wait between every "render"
totalSteps - Default Value: 30 - How many steps there should be between 0 to 1


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1: Make the progress animation smoother](https://issuehunt.io/repos/123488065/issues/1)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->