### PR TITLE
Make the progress animation smoother

### DIFF
--- a/Example/DockProgress Example/AppState.swift
+++ b/Example/DockProgress Example/AppState.swift
@@ -20,17 +20,19 @@ final class AppState: ObservableObject {
 			.bar,
 			.squircle(color: .systemGray),
 			.circle(radius: 30, color: .white),
-			.badge(color: .systemBlue) { Int(DockProgress.progress * 12) },
+			.badge(color: .systemBlue) { Int(DockProgress.animatedProgress * 12) },
 			.pie(color: .systemBlue)
 		]
 
 		var stylesIterator = styles.makeIterator()
-		_ = stylesIterator.next()
+        DockProgress.style = stylesIterator.next()!
+        
+        DockProgress.resetProgress()
 
-		Timer.scheduledTimer(withTimeInterval: 0.02, repeats: true) { _ in
-			DockProgress.progress += 0.01
+        Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
+            DockProgress.progress += 0.2
 
-			if DockProgress.progress > 1 {
+			if DockProgress.animatedProgress >= 1 {
 				if let style = stylesIterator.next() {
 					DockProgress.resetProgress()
 					DockProgress.style = style

--- a/Example/DockProgress Example/AppState.swift
+++ b/Example/DockProgress Example/AppState.swift
@@ -25,12 +25,12 @@ final class AppState: ObservableObject {
 		]
 
 		var stylesIterator = styles.makeIterator()
-        DockProgress.style = stylesIterator.next()!
-        
-        DockProgress.resetProgress()
+		DockProgress.style = stylesIterator.next()!
+		
+		DockProgress.resetProgress()
 
-        Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
-            DockProgress.progress += 0.2
+		Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
+			DockProgress.progress += 0.2
 
 			if DockProgress.animatedProgress >= 1 {
 				if let style = stylesIterator.next() {

--- a/Sources/DockProgress/DockProgress.swift
+++ b/Sources/DockProgress/DockProgress.swift
@@ -15,7 +15,7 @@ public enum DockProgress {
             t = 0
             displayLinkObserver.stop()
         } else {
-            animatedProgress = lerp(animatedProgress, progress, easeInOut(t));
+            animatedProgress = Easing.lerp(animatedProgress, progress, Easing.easeInOut(t));
         }
         updateDockIcon()
     }
@@ -307,21 +307,4 @@ private func displayLinkOutputCallback(
         observer.callback(observer, CVDisplayLinkGetActualOutputVideoRefreshPeriod(displayLink))
     }
     return kCVReturnSuccess
-}
-
-private func lerp(_ start: Double, _ end: Double, _ t: Double) -> Double {
-    return start + (end - start) * t
-}
-
-private func easeIn(_ t: Double) -> Double {
-    // Smoothstep, i.e. approximately iOS's default easing function (see https://stackoverflow.com/a/25728953)
-    return 3 * pow(t, 2) - 2 * pow(t, 3);
-}
-
-private func easeOut(_ t: Double) -> Double {
-    return 1 - easeIn(1 - t)
-}
-
-private func easeInOut(_ t: Double) -> Double {
-    return lerp(easeIn(t), easeOut(t), t)
 }

--- a/Sources/DockProgress/DockProgress.swift
+++ b/Sources/DockProgress/DockProgress.swift
@@ -73,6 +73,9 @@ public enum DockProgress {
 		}
 	}
 	
+	/**
+	The currently displayed progress (readonly). Animates towards `progress`
+	*/
 	public private(set) static var animatedProgress = 0.0
 
 	/**

--- a/Sources/DockProgress/DockProgress.swift
+++ b/Sources/DockProgress/DockProgress.swift
@@ -5,17 +5,17 @@ public enum DockProgress {
 	private static var progressObserver: NSKeyValueObservation?
 	private static var finishedObserver: NSKeyValueObservation?
 
-	private static var t = 0.0
+	private static var elapsedTimeSinceLastRefresh = 0.0
 	private static var displayLinkObserver = DisplayLinkObserver { (displayLinkObserver, refreshPeriod) in
 		DispatchQueue.main.async {
 			let speed = 1.0
-			t += speed * refreshPeriod
+			elapsedTimeSinceLastRefresh += speed * refreshPeriod
 			if (animatedProgress - progress).magnitude <= 0.01 {
 				animatedProgress = progress
-				t = 0
+				elapsedTimeSinceLastRefresh = 0
 				displayLinkObserver.stop()
 			} else {
-				animatedProgress = Easing.lerp(animatedProgress, progress, Easing.easeInOut(t));
+				animatedProgress = Easing.lerp(animatedProgress, progress, Easing.easeInOut(elapsedTimeSinceLastRefresh));
 			}
 			updateDockIcon()
 		}
@@ -82,7 +82,7 @@ public enum DockProgress {
 		displayLinkObserver.stop()
 		progress = 0
 		animatedProgress = 0
-		t = 0;
+		elapsedTimeSinceLastRefresh = 0;
 		updateDockIcon()
 	}
 

--- a/Sources/DockProgress/DockProgress.swift
+++ b/Sources/DockProgress/DockProgress.swift
@@ -18,6 +18,7 @@ public enum DockProgress {
                 if (animatedProgress - progress).magnitude <= 0.01 {
                     animatedProgress = progress
                     t = 0
+                    CVDisplayLinkStop(displayLink)
                 } else {
                     animatedProgress = lerp(animatedProgress, progress, easeInOut(t));
                 }
@@ -28,7 +29,6 @@ public enum DockProgress {
 
         CVDisplayLinkCreateWithActiveCGDisplays(&displayLink)
         CVDisplayLinkSetOutputCallback(displayLink!, displayLinkCallback, nil)
-        CVDisplayLinkStart(displayLink!)
 	}
 
 	public static weak var progressInstance: Progress? {
@@ -69,7 +69,15 @@ public enum DockProgress {
 		}
 	}
 
-	public static var progress: Double = 0
+    public static var progress: Double = 0 {
+        didSet {
+            if let displayLink {
+                if CVDisplayLinkIsRunning(displayLink) == false {
+                    CVDisplayLinkStart(displayLink)
+                }
+            }
+        }
+    }
     
     public private(set) static var animatedProgress: Double = 0
 
@@ -77,6 +85,9 @@ public enum DockProgress {
 	Reset the `progress` without animating.
 	*/
 	public static func resetProgress() {
+        if let displayLink {
+            CVDisplayLinkStop(displayLink)
+        }
 		progress = 0
         animatedProgress = 0
         t = 0;

--- a/Sources/DockProgress/DockProgress.swift
+++ b/Sources/DockProgress/DockProgress.swift
@@ -72,7 +72,7 @@ public enum DockProgress {
         }
     }
     
-    public private(set) static var animatedProgress: Double = 0
+    public private(set) static var animatedProgress = 0.0
 
 	/**
 	Reset the `progress` without animating.

--- a/Sources/DockProgress/DockProgress.swift
+++ b/Sources/DockProgress/DockProgress.swift
@@ -6,19 +6,19 @@ public enum DockProgress {
 	private static var progressObserver: NSKeyValueObservation?
 	private static var finishedObserver: NSKeyValueObservation?
 
-    private static var t = 0.0
-    private static var displayLinkObserver = DisplayLinkObserver { (displayLinkObserver, refreshPeriod) in
-        let speed = 1.0
-        t += speed * refreshPeriod
-        if (animatedProgress - progress).magnitude <= 0.01 {
-            animatedProgress = progress
-            t = 0
-            displayLinkObserver.stop()
-        } else {
-            animatedProgress = Easing.lerp(animatedProgress, progress, Easing.easeInOut(t));
-        }
-        updateDockIcon()
-    }
+	private static var t = 0.0
+	private static var displayLinkObserver = DisplayLinkObserver { (displayLinkObserver, refreshPeriod) in
+		let speed = 1.0
+		t += speed * refreshPeriod
+		if (animatedProgress - progress).magnitude <= 0.01 {
+			animatedProgress = progress
+			t = 0
+			displayLinkObserver.stop()
+		} else {
+			animatedProgress = Easing.lerp(animatedProgress, progress, Easing.easeInOut(t));
+		}
+		updateDockIcon()
+	}
 
 	private static let dockContentView = with(ContentView()) {
 		NSApp.dockTile.contentView = $0
@@ -62,26 +62,26 @@ public enum DockProgress {
 		}
 	}
 
-    public static var progress: Double = 0 {
-        didSet {
-            if progress > 0 {
-                displayLinkObserver.start()
-            } else {
-                updateDockIcon()
-            }
-        }
-    }
-    
-    public private(set) static var animatedProgress = 0.0
+	public static var progress: Double = 0 {
+		didSet {
+			if progress > 0 {
+				displayLinkObserver.start()
+			} else {
+				updateDockIcon()
+			}
+		}
+	}
+	
+	public private(set) static var animatedProgress = 0.0
 
 	/**
 	Reset the `progress` without animating.
 	*/
 	public static func resetProgress() {
-        displayLinkObserver.stop()
+		displayLinkObserver.stop()
 		progress = 0
-        animatedProgress = 0
-        t = 0;
+		animatedProgress = 0
+		t = 0;
 		updateDockIcon()
 	}
 
@@ -98,37 +98,37 @@ public enum DockProgress {
 
 	// TODO: Make the progress smoother by also animating the steps between each call to `updateDockIcon()`
 	private static func updateDockIcon() {
-        dockContentView.needsDisplay = true;
+		dockContentView.needsDisplay = true;
 		NSApp.dockTile.display()
 	}
-    
-    private class ContentView: NSView {
-        override func draw(_ dirtyRect: NSRect) {
-            NSGraphicsContext.current?.imageInterpolation = .high
-            
-            NSApp.applicationIconImage?.draw(in: dirtyRect)
-            
-            // TODO: If the `progress` is 1, draw the full circle, then schedule another draw in n milliseconds to hide it
-            if (animatedProgress <= 0 || animatedProgress >= 1) {
-                return
-            }
+	
+	private class ContentView: NSView {
+		override func draw(_ dirtyRect: NSRect) {
+			NSGraphicsContext.current?.imageInterpolation = .high
+			
+			NSApp.applicationIconImage?.draw(in: dirtyRect)
+			
+			// TODO: If the `progress` is 1, draw the full circle, then schedule another draw in n milliseconds to hide it
+			if (animatedProgress <= 0 || animatedProgress >= 1) {
+				return
+			}
 
-            switch style {
-            case .bar:
-                drawProgressBar(dirtyRect)
-            case .squircle(let inset, let color):
-                drawProgressSquircle(dirtyRect, inset: inset, color: color)
-            case .circle(let radius, let color):
-                drawProgressCircle(dirtyRect, radius: radius, color: color)
-            case .badge(let color, let badgeValue):
-                drawProgressBadge(dirtyRect, color: color, badgeLabel: badgeValue())
-            case .pie(let color):
-                drawProgressBadge(dirtyRect, color: color, badgeLabel: 0, isPie: true)
-            case .custom(let drawingHandler):
-                drawingHandler(dirtyRect)
-            }
-        }
-    }
+			switch style {
+			case .bar:
+				drawProgressBar(dirtyRect)
+			case .squircle(let inset, let color):
+				drawProgressSquircle(dirtyRect, inset: inset, color: color)
+			case .circle(let radius, let color):
+				drawProgressCircle(dirtyRect, radius: radius, color: color)
+			case .badge(let color, let badgeValue):
+				drawProgressBadge(dirtyRect, color: color, badgeLabel: badgeValue())
+			case .pie(let color):
+				drawProgressBadge(dirtyRect, color: color, badgeLabel: 0, isPie: true)
+			case .custom(let drawingHandler):
+				drawingHandler(dirtyRect)
+			}
+		}
+	}
 
 	private static func drawProgressBar(_ dstRect: CGRect) {
 		func roundedRect(_ rect: CGRect) {
@@ -268,43 +268,43 @@ public enum DockProgress {
 private typealias DisplayLinkObserverCallback = (DisplayLinkObserver, Double) -> Void;
 
 private class DisplayLinkObserver {
-    private var displayLink: CVDisplayLink?
-    var callback: DisplayLinkObserverCallback
-    
-    init(_ callback: @escaping DisplayLinkObserverCallback) {
-        self.callback = callback
-        CVDisplayLinkCreateWithActiveCGDisplays(&displayLink)
-    }
-    
-    func start() {
-        if let displayLink {
-            CVDisplayLinkSetOutputCallback(
-                displayLink,
-                displayLinkOutputCallback,
-                UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
-            )
-            CVDisplayLinkStart(displayLink)
-        }
-    }
-    
-    func stop() {
-        if let displayLink {
-            CVDisplayLinkStop(displayLink)
-        }
-    }
+	private var displayLink: CVDisplayLink?
+	var callback: DisplayLinkObserverCallback
+	
+	init(_ callback: @escaping DisplayLinkObserverCallback) {
+		self.callback = callback
+		CVDisplayLinkCreateWithActiveCGDisplays(&displayLink)
+	}
+	
+	func start() {
+		if let displayLink {
+			CVDisplayLinkSetOutputCallback(
+				displayLink,
+				displayLinkOutputCallback,
+				UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+			)
+			CVDisplayLinkStart(displayLink)
+		}
+	}
+	
+	func stop() {
+		if let displayLink {
+			CVDisplayLinkStop(displayLink)
+		}
+	}
 }
 
 private func displayLinkOutputCallback(
-    displayLink: CVDisplayLink,
-    inNow: UnsafePointer<CVTimeStamp>,
-    inOutputTime: UnsafePointer<CVTimeStamp>,
-    flagsIn: CVOptionFlags,
-    flagsOut: UnsafeMutablePointer<CVOptionFlags>,
-    displayLinkContext: UnsafeMutableRawPointer?
+	displayLink: CVDisplayLink,
+	inNow: UnsafePointer<CVTimeStamp>,
+	inOutputTime: UnsafePointer<CVTimeStamp>,
+	flagsIn: CVOptionFlags,
+	flagsOut: UnsafeMutablePointer<CVOptionFlags>,
+	displayLinkContext: UnsafeMutableRawPointer?
 ) -> CVReturn {
-    Task { @MainActor in
-        let observer = unsafeBitCast(displayLinkContext, to: DisplayLinkObserver.self)
-        observer.callback(observer, CVDisplayLinkGetActualOutputVideoRefreshPeriod(displayLink))
-    }
-    return kCVReturnSuccess
+	Task { @MainActor in
+		let observer = unsafeBitCast(displayLinkContext, to: DisplayLinkObserver.self)
+		observer.callback(observer, CVDisplayLinkGetActualOutputVideoRefreshPeriod(displayLink))
+	}
+	return kCVReturnSuccess
 }

--- a/Sources/DockProgress/Utilities.swift
+++ b/Sources/DockProgress/Utilities.swift
@@ -1,5 +1,5 @@
 import Cocoa
-
+import simd
 
 /**
 Convenience function for initializing an object and modifying its properties.
@@ -268,4 +268,22 @@ final class VerticallyCenteredTextLayer: CATextLayer {
 		super.draw(in: context)
 		context.restoreGState()
 	}
+}
+
+enum Easing {
+    static func lerp(_ start: Double, _ end: Double, _ t: Double) -> Double {
+        return Double(simd_mix(Float(start), Float(end), Float(t)))
+    }
+
+    static private func easeIn(_ t: Double) -> Double {
+        return Double(simd_smoothstep(0.0, 1.0, Float(t)))
+    }
+
+    static private func easeOut(_ t: Double) -> Double {
+        return 1 - easeIn(1 - t)
+    }
+
+    static func easeInOut(_ t: Double) -> Double {
+        return lerp(easeIn(t), easeOut(t), t)
+    }
 }

--- a/Sources/DockProgress/Utilities.swift
+++ b/Sources/DockProgress/Utilities.swift
@@ -271,19 +271,19 @@ final class VerticallyCenteredTextLayer: CATextLayer {
 }
 
 enum Easing {
-    static func lerp(_ start: Double, _ end: Double, _ t: Double) -> Double {
-        return Double(simd_mix(Float(start), Float(end), Float(t)))
-    }
+	static func lerp(_ start: Double, _ end: Double, _ t: Double) -> Double {
+		return Double(simd_mix(Float(start), Float(end), Float(t)))
+	}
 
-    static private func easeIn(_ t: Double) -> Double {
-        return Double(simd_smoothstep(0.0, 1.0, Float(t)))
-    }
+	static private func easeIn(_ t: Double) -> Double {
+		return Double(simd_smoothstep(0.0, 1.0, Float(t)))
+	}
 
-    static private func easeOut(_ t: Double) -> Double {
-        return 1 - easeIn(1 - t)
-    }
+	static private func easeOut(_ t: Double) -> Double {
+		return 1 - easeIn(1 - t)
+	}
 
-    static func easeInOut(_ t: Double) -> Double {
-        return lerp(easeIn(t), easeOut(t), t)
-    }
+	static func easeInOut(_ t: Double) -> Double {
+		return lerp(easeIn(t), easeOut(t), t)
+	}
 }

--- a/Sources/DockProgress/Utilities.swift
+++ b/Sources/DockProgress/Utilities.swift
@@ -335,8 +335,8 @@ private func displayLinkOutputCallback(
 	let observer = unsafeBitCast(displayLinkContext, to: DisplayLinkObserver.self)
 	var refreshPeriod = CVDisplayLinkGetActualOutputVideoRefreshPeriod(displayLink)
 	if (refreshPeriod == 0) {
-		print("Warning: CVDisplayLinkGetActualOutputVideoRefreshPeriod failed. Assuming 30 Hz...")
-		refreshPeriod = 1.0 / 30.0
+		print("Warning: CVDisplayLinkGetActualOutputVideoRefreshPeriod failed. Assuming 60 Hz...")
+		refreshPeriod = 1.0 / 60.0
 	}
 	observer.callback(observer, refreshPeriod)
 	return kCVReturnSuccess


### PR DESCRIPTION
Animates progress between discreet progress value updates from user.

Implemented using a CVDisplayLink. Doing it this way also substantially improves efficiency if the user is updating `progress` very frequently, i.e. we only trigger a redraw at the constant refresh rate.

I've tested with various different rates and it seems to work reasonably well even in "stress" cases. Let me know if there is a test/usecase that I have overlooked or if the "feel" should be tweaked.

I have also tweaked the example app to showcase / test and made a minor fix to it.

Closes #1


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1: Make the progress animation smoother](https://oss.issuehunt.io/repos/123488065/issues/1)
---
</details>
<!-- /Issuehunt content-->